### PR TITLE
[#105] Group Encounterform fields together

### DIFF
--- a/app/src/components/EncounterForm.jsx
+++ b/app/src/components/EncounterForm.jsx
@@ -8,6 +8,7 @@ import utilities from "../materials/utilities";
 import { constructDateTime } from "../utils/time";
 import Button from "./Button";
 import ListHeader from "./list/ListHeader";
+import ListSubheader from "./list/ListSubheader";
 
 import TextInput from "./formFields/TextInput/TextInput";
 import TextAreaInput from "./formFields/TextAreaInput/TextAreaInput";
@@ -107,8 +108,10 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
         >
           {({ values, submitForm }) => (
             <Form>
-              <div css={utilities.form.fieldsGrid}>
-                <ListHeader title="Encounter details">
+              <ListHeader title="Encounter details">
+                <div
+                  css={[utilities.form.subsection, utilities.form.fieldsGrid]}
+                >
                   <DateInput
                     name="startTimestamp"
                     labelText="Date"
@@ -140,7 +143,11 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                     isRequired
                     isDisabled={isViewOnly}
                   />
-                  <br />
+                </div>
+                <br />
+                <div
+                  css={[utilities.form.subsection, utilities.form.fieldsGrid]}
+                >
                   <Select
                     name="project"
                     labelText="Project"
@@ -186,32 +193,12 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                     maxLength={500}
                     isDisabled={isViewOnly}
                   />
-                </ListHeader>
-                <ListHeader title="Evidence">
-                  <TextInput
-                    name="videoRec"
-                    labelText="Video rec"
-                    maxLength={50}
-                    isDisabled={isViewOnly}
-                  />
-                  <TextInput
-                    name="audioRec"
-                    labelText="Audio rec"
-                    maxLength={255}
-                    isDisabled={isViewOnly}
-                  />
-                  <TextInput
-                    name="photographerFrame"
-                    labelText="Photographer + Frame"
-                    maxLength={255}
-                    isDisabled={isViewOnly}
-                  />
-                  <TextAreaInput
-                    name="visualIdentifications"
-                    labelText="Visual identifications"
-                    maxLength={200}
-                    isDisabled={isViewOnly}
-                  />
+                </div>
+              </ListHeader>
+              <ListHeader title="Evidence">
+                <div
+                  css={[utilities.form.subsection, utilities.form.fieldsGrid]}
+                >
                   <RadioGroup
                     name="biopsyAttempt"
                     labelText="Biopsy attempt"
@@ -266,10 +253,38 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                     isShort
                     isDisabled={isViewOnly}
                   />
-                </ListHeader>
-                <ListHeader title="Age Class">
-                  <fieldset>
-                    <legend>Number of Adult</legend>
+                  <TextInput
+                    name="videoRec"
+                    labelText="Video rec"
+                    maxLength={50}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="audioRec"
+                    labelText="Audio rec"
+                    maxLength={255}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="photographerFrame"
+                    labelText="Photographer + Frame"
+                    maxLength={255}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextAreaInput
+                    name="visualIdentifications"
+                    labelText="Visual identifications"
+                    maxLength={200}
+                    isDisabled={isViewOnly}
+                  />
+                </div>
+              </ListHeader>
+              <ListHeader title="Age Class">
+                <fieldset css={utilities.form.fieldset}>
+                  <legend>
+                    <ListSubheader title="Number of Adult" />
+                  </legend>
+                  <div css={utilities.form.subsection}>
                     <NumberInput
                       name="numAdultMale"
                       labelText="Male"
@@ -297,9 +312,13 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                       isInteger
                       isDisabled={isViewOnly}
                     />
-                  </fieldset>
-                  <fieldset>
-                    <legend>Number of sub adult</legend>
+                  </div>
+                </fieldset>
+                <fieldset css={utilities.form.fieldset}>
+                  <legend>
+                    <ListSubheader title="Number of sub adult" />
+                  </legend>
+                  <div css={utilities.form.subsection}>
                     <NumberInput
                       name="numSubAdultMale"
                       labelText="Male"
@@ -327,9 +346,13 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                       isInteger
                       isDisabled={isViewOnly}
                     />
-                  </fieldset>
-                  <fieldset>
-                    <legend>Number of juvenile</legend>
+                  </div>
+                </fieldset>
+                <fieldset css={utilities.form.fieldset}>
+                  <legend>
+                    <ListSubheader title="Number of juvenile" />
+                  </legend>
+                  <div css={utilities.form.subsection}>
                     <NumberInput
                       name="numJuvenileMale"
                       labelText="Male"
@@ -357,9 +380,13 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                       isInteger
                       isDisabled={isViewOnly}
                     />
-                  </fieldset>
-                  <fieldset>
-                    <legend>Number of Other</legend>
+                  </div>
+                </fieldset>
+                <fieldset css={utilities.form.fieldset}>
+                  <legend>
+                    <ListSubheader title="Number of Other" />
+                  </legend>
+                  <div css={utilities.form.subsection}>
                     <NumberInput
                       name="numYoungOfYear"
                       labelText="Young of year"
@@ -387,9 +414,13 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                       isInteger
                       isDisabled={isViewOnly}
                     />
-                  </fieldset>
-                </ListHeader>
-                <ListHeader title="Encounter completion">
+                  </div>
+                </fieldset>
+              </ListHeader>
+              <ListHeader title="Encounter completion">
+                <div
+                  css={[utilities.form.subsection, utilities.form.fieldsGrid]}
+                >
                   <Select
                     name="reasonForLeaving"
                     labelText="Reason for leaving"
@@ -487,8 +518,8 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                     ]}
                     isDisabled={isViewOnly}
                   />
-                </ListHeader>
-              </div>
+                </div>
+              </ListHeader>
               <div css={utilities.form.h2}>
                 <span>*</span>required fields
               </div>

--- a/app/src/components/EncounterForm.jsx
+++ b/app/src/components/EncounterForm.jsx
@@ -520,7 +520,7 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
                   />
                 </div>
               </ListHeader>
-              <div css={utilities.form.h2}>
+              <div css={utilities.form.legend}>
                 <span>*</span>required fields
               </div>
               {!isViewOnly && (

--- a/app/src/components/EncounterForm.jsx
+++ b/app/src/components/EncounterForm.jsx
@@ -7,6 +7,7 @@ import add from "date-fns/add";
 import utilities from "../materials/utilities";
 import { constructDateTime } from "../utils/time";
 import Button from "./Button";
+import ListHeader from "./list/ListHeader";
 
 import TextInput from "./formFields/TextInput/TextInput";
 import TextAreaInput from "./formFields/TextAreaInput/TextAreaInput";
@@ -107,361 +108,388 @@ const EncounterForm = ({ initialValues, handleSubmit, isViewOnly }) => {
           {({ values, submitForm }) => (
             <Form>
               <div css={utilities.form.fieldsGrid}>
-                <DateInput
-                  name="startTimestamp"
-                  labelText="Date"
-                  isRequired
-                  isShort
-                  notAfter={new Date()}
-                  autofill={!initialValues}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="sequenceNumber"
-                  labelText="Encounter sequence"
-                  maxLength={255}
-                  isRequired
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="area"
-                  labelText="Area"
-                  options={area}
-                  isRequired
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="species"
-                  labelText="Species"
-                  options={species}
-                  isRequired
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="project"
-                  labelText="Project"
-                  options={project}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="cue"
-                  labelText="Cue"
-                  options={cue}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="vessel"
-                  labelText="Vessel"
-                  options={vessel}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="observers"
-                  labelText="Observers"
-                  maxLength={100}
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="groupSize"
-                  labelText="Group size (visual)"
-                  minValue={1}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="location"
-                  labelText="Location"
-                  maxLength={100}
-                  isDisabled={isViewOnly}
-                />
-                <TextAreaInput
-                  name="comments"
-                  labelText="Comments / Observations (names of underwater observers)"
-                  maxLength={500}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="videoRec"
-                  labelText="Video rec"
-                  maxLength={50}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="audioRec"
-                  labelText="Audio rec"
-                  maxLength={255}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="photographerFrame"
-                  labelText="Photographer + Frame"
-                  maxLength={255}
-                  isDisabled={isViewOnly}
-                />
-                <TextAreaInput
-                  name="visualIdentifications"
-                  labelText="Visual identifications"
-                  maxLength={200}
-                  isDisabled={isViewOnly}
-                />
-                <RadioGroup
-                  name="biopsyAttempt"
-                  labelText="Biopsy attempt"
-                  options={[
-                    { label: "Yes", value: "Yes" },
-                    { label: "No", value: "No" },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
-                <RadioGroup
-                  name="biopsySuccess"
-                  labelText="Biopsy success"
-                  options={[
-                    { label: "Yes", value: "Yes" },
-                    { label: "No", value: "No" },
-                    { label: "Not noted", value: "not-noted" },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
-                <RadioGroup
-                  name="tagAttempt"
-                  labelText="Tag attempt"
-                  options={[
-                    { label: "Yes", value: "Yes" },
-                    { label: "No", value: "No" },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
-                <RadioGroup
-                  name="tagSuccess"
-                  labelText="Tag success"
-                  options={[
-                    { label: "Yes", value: "Yes" },
-                    { label: "No", value: "No" },
-                    { label: "Not noted", value: "not-noted" },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
-                <RadioGroup
-                  name="transect"
-                  labelText="Transect"
-                  options={[
-                    { label: "On", value: "On" },
-                    { label: "Off", value: "Off" },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="transectNumber"
-                  labelText="Transect number"
-                  maxLength={8}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numAdultMale"
-                  labelText="Number of adult male"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numAdultFemale"
-                  labelText="Number of adult female"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numAdultUnknown"
-                  labelText="Number of adult unknown"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numSubAdultMale"
-                  labelText="Number of sub adult male"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numSubAdultFemale"
-                  labelText="Number of sub adult female"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numSubAdult"
-                  labelText="Number of sub adult"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numJuvenileMale"
-                  labelText="Number of juvenile male"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numJuvenileFemale"
-                  labelText="Number of juvenile female"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numJuvenileUnknown"
-                  labelText="Number of juvenile unknown"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numYoungOfYear"
-                  labelText="Number of young of year"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numNeonates"
-                  labelText="Number of neonates"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numUnknown"
-                  labelText="Number of unknown"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="endOfSearchEffort"
-                  labelText="End of search effort"
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <DateInput
-                  name="endTimestamp"
-                  labelText="End date"
-                  isShort
-                  autofill={!initialValues}
-                  notBefore={values.startTimestamp}
-                  notAfter={add(new Date(values.startTimestamp), {
-                    hours: THREE_DAYS_IN_HOURS,
-                  })}
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="endTime"
-                  labelText="End time"
-                  isShort
-                  associatedDate={values.endTimestamp}
-                  notBefore={constructDateTime(
-                    values.startTimestamp,
-                    values.startTime
-                  )}
-                  notAfter={add(
-                    constructDateTime(values.startTimestamp, values.startTime),
-                    { hours: THREE_DAYS_IN_HOURS }
-                  )}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="reasonForLeaving"
-                  labelText="Reason for leaving"
-                  options={reasonForLeaving}
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="highTide"
-                  labelText="High tide"
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="lowTide"
-                  labelText="Low tide"
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="logbookNumber"
-                  labelText="Logbook number"
-                  maxLength={20}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="encounterNumber"
-                  labelText="Encounter number"
-                  minValue={1}
-                  maxValue={999}
-                  isShort
-                  isInteger
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="startTime"
-                  labelText="Start time"
-                  isShort
-                  autofill={!initialValues}
-                  notAfter={values.startTimestamp}
-                  isRequired
-                  isDisabled={isViewOnly}
-                />
-                <ElapsedTime isDisabled={isViewOnly} />
-                <RadioGroup
-                  name="enteredBy"
-                  labelText="Entered by"
-                  options={[
-                    {
-                      label: RESEARCH_ASSISTANT,
-                      value: RESEARCH_ASSISTANT,
-                    },
-                    {
-                      label: RESEARCH_SCIENTIST,
-                      value: RESEARCH_SCIENTIST,
-                    },
-                  ]}
-                  isDisabled={isViewOnly}
-                />
+                <ListHeader title="Encounter details">
+                  <DateInput
+                    name="startTimestamp"
+                    labelText="Date"
+                    isRequired
+                    isShort
+                    notAfter={new Date()}
+                    autofill={!initialValues}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="sequenceNumber"
+                    labelText="Encounter sequence"
+                    maxLength={255}
+                    isRequired
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="area"
+                    labelText="Area"
+                    options={area}
+                    isRequired
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="species"
+                    labelText="Species"
+                    options={species}
+                    isRequired
+                    isDisabled={isViewOnly}
+                  />
+                  <br />
+                  <Select
+                    name="project"
+                    labelText="Project"
+                    options={project}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="cue"
+                    labelText="Cue"
+                    options={cue}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="observers"
+                    labelText="Observers"
+                    maxLength={100}
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="groupSize"
+                    labelText="Group size (visual)"
+                    minValue={1}
+                    maxValue={9999}
+                    isShort
+                    isInteger
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="location"
+                    labelText="Location"
+                    maxLength={100}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="vessel"
+                    labelText="Vessel"
+                    options={vessel}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextAreaInput
+                    name="comments"
+                    labelText="Comments / Observations (names of underwater observers)"
+                    maxLength={500}
+                    isDisabled={isViewOnly}
+                  />
+                </ListHeader>
+                <ListHeader title="Evidence">
+                  <TextInput
+                    name="videoRec"
+                    labelText="Video rec"
+                    maxLength={50}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="audioRec"
+                    labelText="Audio rec"
+                    maxLength={255}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="photographerFrame"
+                    labelText="Photographer + Frame"
+                    maxLength={255}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextAreaInput
+                    name="visualIdentifications"
+                    labelText="Visual identifications"
+                    maxLength={200}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="biopsyAttempt"
+                    labelText="Biopsy attempt"
+                    options={[
+                      { label: "Yes", value: "Yes" },
+                      { label: "No", value: "No" },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="biopsySuccess"
+                    labelText="Biopsy success"
+                    options={[
+                      { label: "Yes", value: "Yes" },
+                      { label: "No", value: "No" },
+                      { label: "Not noted", value: "not-noted" },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="tagAttempt"
+                    labelText="Tag attempt"
+                    options={[
+                      { label: "Yes", value: "Yes" },
+                      { label: "No", value: "No" },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="tagSuccess"
+                    labelText="Tag success"
+                    options={[
+                      { label: "Yes", value: "Yes" },
+                      { label: "No", value: "No" },
+                      { label: "Not noted", value: "not-noted" },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="transect"
+                    labelText="Transect"
+                    options={[
+                      { label: "On", value: "On" },
+                      { label: "Off", value: "Off" },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="transectNumber"
+                    labelText="Transect number"
+                    maxLength={8}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                </ListHeader>
+                <ListHeader title="Age Class">
+                  <fieldset>
+                    <legend>Number of Adult</legend>
+                    <NumberInput
+                      name="numAdultMale"
+                      labelText="Male"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numAdultFemale"
+                      labelText="Female"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numAdultUnknown"
+                      labelText="Unknown"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                  </fieldset>
+                  <fieldset>
+                    <legend>Number of sub adult</legend>
+                    <NumberInput
+                      name="numSubAdultMale"
+                      labelText="Male"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numSubAdultFemale"
+                      labelText="Female"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numSubAdult"
+                      labelText="Unknown"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                  </fieldset>
+                  <fieldset>
+                    <legend>Number of juvenile</legend>
+                    <NumberInput
+                      name="numJuvenileMale"
+                      labelText="Male"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numJuvenileFemale"
+                      labelText="Female"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numJuvenileUnknown"
+                      labelText="Unknown"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                  </fieldset>
+                  <fieldset>
+                    <legend>Number of Other</legend>
+                    <NumberInput
+                      name="numYoungOfYear"
+                      labelText="Young of year"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numNeonates"
+                      labelText="Neonates"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                    <NumberInput
+                      name="numUnknown"
+                      labelText="Unknown"
+                      minValue={0}
+                      maxValue={9999}
+                      isShort
+                      isInteger
+                      isDisabled={isViewOnly}
+                    />
+                  </fieldset>
+                </ListHeader>
+                <ListHeader title="Encounter completion">
+                  <Select
+                    name="reasonForLeaving"
+                    labelText="Reason for leaving"
+                    options={reasonForLeaving}
+                    isDisabled={isViewOnly}
+                  />
+                  <TimeInput
+                    name="endOfSearchEffort"
+                    labelText="End of search effort"
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="logbookNumber"
+                    labelText="Logbook number"
+                    maxLength={20}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="encounterNumber"
+                    labelText="Encounter number"
+                    minValue={1}
+                    maxValue={999}
+                    isShort
+                    isInteger
+                    isDisabled={isViewOnly}
+                  />
+
+                  <TimeInput
+                    name="highTide"
+                    labelText="High tide"
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <TimeInput
+                    name="lowTide"
+                    labelText="Low tide"
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <TimeInput
+                    name="startTime"
+                    labelText="Start time"
+                    isShort
+                    autofill={!initialValues}
+                    notAfter={values.startTimestamp}
+                    isRequired
+                    isDisabled={isViewOnly}
+                  />
+
+                  <TimeInput
+                    name="endTime"
+                    labelText="End time"
+                    isShort
+                    associatedDate={values.endTimestamp}
+                    notBefore={constructDateTime(
+                      values.startTimestamp,
+                      values.startTime
+                    )}
+                    notAfter={add(
+                      constructDateTime(
+                        values.startTimestamp,
+                        values.startTime
+                      ),
+                      { hours: THREE_DAYS_IN_HOURS }
+                    )}
+                    isDisabled={isViewOnly}
+                  />
+
+                  <ElapsedTime isDisabled={isViewOnly} />
+                  <DateInput
+                    name="endTimestamp"
+                    labelText="End date"
+                    isShort
+                    autofill={!initialValues}
+                    notBefore={values.startTimestamp}
+                    notAfter={add(new Date(values.startTimestamp), {
+                      hours: THREE_DAYS_IN_HOURS,
+                    })}
+                    isDisabled={isViewOnly}
+                  />
+                  <RadioGroup
+                    name="enteredBy"
+                    labelText="Entered by"
+                    options={[
+                      {
+                        label: RESEARCH_ASSISTANT,
+                        value: RESEARCH_ASSISTANT,
+                      },
+                      {
+                        label: RESEARCH_SCIENTIST,
+                        value: RESEARCH_SCIENTIST,
+                      },
+                    ]}
+                    isDisabled={isViewOnly}
+                  />
+                </ListHeader>
               </div>
-              <div css={utilities.form.legend}>
+              <div css={utilities.form.h2}>
                 <span>*</span>required fields
               </div>
               {!isViewOnly && (

--- a/app/src/components/EncounterList.jsx
+++ b/app/src/components/EncounterList.jsx
@@ -89,21 +89,22 @@ const TodaysEncounters = ({ encounters }) => {
 const EncounterList = ({ title, encounters, loadMore, isToday, isLoading }) => {
   return (
     <div css={utilities.list.container}>
-      <ListHeader title={title} />
-      {!encounters.length ? (
-        <div css={utilities.list.noEntries}>No encounters yet</div>
-      ) : isToday ? (
-        <TodaysEncounters encounters={encounters} />
-      ) : (
-        <PreviousEncounters encounters={encounters} />
-      )}
-      {!!loadMore && (
-        <LoadMoreButton
-          text="Load previous month"
-          handleClick={loadMore}
-          isLoading={isLoading}
-        />
-      )}
+      <ListHeader title={title}>
+        {!encounters.length ? (
+          <div css={utilities.list.noEntries}>No encounters yet</div>
+        ) : isToday ? (
+          <TodaysEncounters encounters={encounters} />
+        ) : (
+          <PreviousEncounters encounters={encounters} />
+        )}
+        {!!loadMore && (
+          <LoadMoreButton
+            text="Load previous month"
+            handleClick={loadMore}
+            isLoading={isLoading}
+          />
+        )}
+      </ListHeader>
     </div>
   );
 };

--- a/app/src/components/__tests__/EncounterForm.test.js
+++ b/app/src/components/__tests__/EncounterForm.test.js
@@ -43,6 +43,37 @@ describe("EncounterForm", () => {
     expect(formValues.startTime).toEqual("11:30");
   });
 
+  it("Form contains four fieldsets with the correct associated names", async () => {
+    const mockHandleSubmit = jest.fn();
+
+    const { queryAllByRole, getByRole } = render(
+      <EncounterForm handleSubmit={mockHandleSubmit} />
+    );
+
+    const fieldsets = queryAllByRole("group");
+    expect(fieldsets.length).toBe(4);
+
+    await waitFor(() => {
+      const adultFieldset = getByRole("group", { name: "Number of Adult" });
+      expect(adultFieldset).not.toBeNull();
+
+      const subAdultFieldset = getByRole("group", {
+        name: "Number of sub adult",
+      });
+      expect(subAdultFieldset).not.toBeNull();
+
+      const juvenileFieldset = getByRole("group", {
+        name: "Number of juvenile",
+      });
+      expect(juvenileFieldset).not.toBeNull();
+
+      const otherFieldset = getByRole("group", {
+        name: "Number of Other",
+      });
+      expect(otherFieldset).not.toBeNull();
+    });
+  });
+
   it("displays error and doesn't submit the form if required fields are not completed", async () => {
     const mockHandleSubmit = jest.fn();
 

--- a/app/src/components/list/ListHeader.jsx
+++ b/app/src/components/list/ListHeader.jsx
@@ -7,25 +7,25 @@ import typography from "../../materials/typography";
 const ListHeader = ({ title, children }) => {
   const styles = {
     listHeader: css`
+      margin-top: 20px;
+      width: 100%;
+    `,
+    title: css`
       background: ${colors.lightTurquoise};
       display: flex;
       align-items: center;
       justify-content: space-between;
-      width: 100%;
       padding: 10px;
-      margin-top: 20px;
-    `,
-    title: css`
       ${typography.largeText}
       font-weight: 600;
     `,
   };
 
   return (
-    <div css={styles.listHeader}>
-      <p css={styles.title}>{title}</p>
+    <section css={styles.listHeader}>
+      <h2 css={styles.title}>{title}</h2>
       {children}
-    </div>
+    </section>
   );
 };
 

--- a/app/src/materials/utilities.js
+++ b/app/src/materials/utilities.js
@@ -29,6 +29,18 @@ const utilities = {
         margin-right: 5px;
       }
     `,
+    fieldset: css`
+      border: none;
+      margin: 0;
+      padding: 0;
+    `,
+    subsection: css`
+      background-color: ${colors.white};
+      padding: 20px 10px;
+      @media (min-width: ${breakPoints.maxPhone}) {
+        display: flex;
+      }
+    `,
   },
   sticky: {
     contentContainer: css`

--- a/app/src/materials/utilities.js
+++ b/app/src/materials/utilities.js
@@ -36,7 +36,7 @@ const utilities = {
     `,
     subsection: css`
       background-color: ${colors.white};
-      padding: 20px 10px;
+      padding: 20px 10px 10px;
       @media (min-width: ${breakPoints.maxPhone}) {
         display: flex;
       }


### PR DESCRIPTION
# Group Encounterform fields together
- Includes refactor of `< ListHeader/>` - the title to be an `h2` and outside `div` to be a `section` tag instead. More semantically correct & accessible. Made sure it doesn't visually affect the other pages that use `<ListHeader/>`
- Adjusted the styling, and grouped inputs as appropriate
    - I realise this form is getting to be a `div` soup - open to suggestions!
    - Also realise this `<EncounterForm/>` is getting pretty large - let me know and I can split it into smaller chunks
- I've predominantly used the tablet view design to group the inputs, though the inputs do not match the ordering on the mobile design. Is this intentional 🤔 if so I will try and swap the inputs around on mobile view (though it feels like it should match). Let me know! Thanks 😊

NB for some reason the grey background isn't showing up on the Giphy gifs, but it is there:

<img width="919" alt="Screenshot 2020-09-01 at 15 53 46" src="https://user-images.githubusercontent.com/25727036/91867290-634f0400-ec6b-11ea-95de-d0c97653ec8f.png">

![Tablet-preview](https://user-images.githubusercontent.com/25727036/91866954-fdfb1300-ec6a-11ea-823f-62b1210502be.gif)

![Mobile-preview](https://user-images.githubusercontent.com/25727036/91866938-f9365f00-ec6a-11ea-87f8-b31f487c2c9c.gif)

## References 
- Example where a form has `section` and `h2`, then within that section there are `fieldset`s: https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form
- General info on `fieldset`s - https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/ (recommendation not to nest fieldsets