### PR TITLE
106 habitat grouping

### DIFF
--- a/app/src/components/HabitatUseForm.jsx
+++ b/app/src/components/HabitatUseForm.jsx
@@ -28,6 +28,8 @@ import groupCohesion from "../constants/formOptions/groupCohesion";
 import { generateOpenEncounterURL } from "../constants/routes";
 import habitatUseDefaults from "../constants/habitatUseDefaultValues";
 import NumberWithCheckbox from "./formFields/NumberWithCheckbox/NumberWithCheckbox";
+import ListHeader from "./list/ListHeader";
+import FormSection from "./FormSection";
 
 const HabitatUseForm = ({
   initialValues,
@@ -40,6 +42,9 @@ const HabitatUseForm = ({
   const styles = {
     cancelButton: css`
       margin-right: 10px;
+    `,
+    section: css`
+      background-color: none;
     `,
   };
 
@@ -60,196 +65,220 @@ const HabitatUseForm = ({
         <Formik initialValues={initValues} onSubmit={handleSubmit}>
           {({ values }) => (
             <Form>
-              <div css={utilities.form.fieldsGrid}>
-                <NumberInput
-                  name="numberOfAnimals"
-                  labelText="Number of animals"
-                  minValue={0}
-                  maxValue={99}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numberOfCalves"
-                  labelText="Number of calves"
-                  minValue={0}
-                  maxValue={99}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="numberOfBoats"
-                  labelText="Number of boats"
-                  minValue={0}
-                  maxValue={999}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="directionOfTravel"
-                  labelText="Direction of travel"
-                  options={direction}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <TextAreaInput
-                  name="comments"
-                  labelText="Comments"
-                  maxLength={500}
-                  isDisabled={isViewOnly}
-                />
-                <NumberWithCheckbox
-                  numberInputName="waterDepth"
-                  labelText="Water depth (m)"
-                  minValue={0}
-                  maxValue={9999}
-                  isShort
-                  decimalPrecision={3}
-                  isDisabled={isViewOnly}
-                  checkboxName="waterDepthBeyondSoundings"
-                  checkboxLabel="Beyond soundings"
-                />
-                <NumberInput
-                  name="waterTemp"
-                  labelText="Water temp (°C)"
-                  minValue={15}
-                  maxValue={40}
-                  isShort
-                  decimalPrecision={5}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="bottomSubstrate"
-                  labelText="Bottom substrate"
-                  options={bottomSubstrate}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="cloudCover"
-                  labelText="Cloud cover"
-                  options={cloudCover}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="beaufortSeaState"
-                  labelText="Beaufort sea state"
-                  options={beaufortSeaState}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="tideState"
-                  labelText="Tide state"
-                  options={tideState}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="behaviour"
-                  labelText="Behaviour"
-                  options={behaviour}
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="swellWaveHeight"
-                  labelText="Swell / Wave height (ft)"
-                  options={swellWaveHeight}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="distance"
-                  labelText="Distance (m)"
-                  minValue={0}
-                  maxValue={9999}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="bearing"
-                  labelText="Bearing (°)"
-                  minValue={0}
-                  maxValue={360}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="aspect"
-                  labelText="Aspect (°)"
-                  minValue={0}
-                  maxValue={360}
-                  isInteger
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <Select
-                  name="groupCohesion"
-                  labelText="Group cohesion"
-                  options={groupCohesion}
-                  isDisabled={isViewOnly}
-                />
-                <TextAreaInput
-                  name="groupComposition"
-                  labelText="Group composition"
-                  maxLength={255}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-                <NumberInput
-                  name="surfaceBout"
-                  labelText="Surface bout"
-                  minValue={0}
-                  maxValue={99}
-                  isShort
-                  decimalPrecision={5}
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="endTime"
-                  labelText="End time (hh:mm:ss)"
-                  notBefore={values.startTime}
-                  isShort
-                  timeWithSeconds
-                  isDisabled={isViewOnly}
-                />
-                <TimeInput
-                  name="startTime"
-                  labelText="Start time (hh:mm:ss)"
-                  isRequired
-                  isShort
-                  autofill={!initialValues}
-                  timeWithSeconds
-                  isDisabled={isViewOnly}
-                />
-                <PositionInput
-                  name="latitude"
-                  type="latitude"
-                  labelText="Lat"
-                  isShort
-                  autofill={!initialValues}
-                  isDisabled={isViewOnly}
-                />
-                <PositionInput
-                  name="longitude"
-                  type="longitude"
-                  labelText="Long"
-                  isShort
-                  autofill={!initialValues}
-                  isDisabled={isViewOnly}
-                />
-                <TextInput
-                  name="gpsMark"
-                  labelText="GPS mark"
-                  maxLength={10}
-                  isShort
-                  isDisabled={isViewOnly}
-                />
-              </div>
+              <section css={styles.section}>
+                <ListHeader title="Time & position" />
+                <FormSection>
+                  <TimeInput
+                    name="startTime"
+                    labelText="Start time (hh:mm:ss)"
+                    isRequired
+                    isShort
+                    autofill={!initialValues}
+                    timeWithSeconds
+                    isDisabled={isViewOnly}
+                  />
+                  <TimeInput
+                    name="endTime"
+                    labelText="End time (hh:mm:ss)"
+                    notBefore={values.startTime}
+                    isShort
+                    timeWithSeconds
+                    isDisabled={isViewOnly}
+                  />
+                </FormSection>
+                <br />
+                <FormSection isOneLine>
+                  <PositionInput
+                    name="latitude"
+                    type="latitude"
+                    labelText="Lat"
+                    isShort
+                    autofill={!initialValues}
+                    isDisabled={isViewOnly}
+                  />
+                  <PositionInput
+                    name="longitude"
+                    type="longitude"
+                    labelText="Long"
+                    isShort
+                    autofill={!initialValues}
+                    isDisabled={isViewOnly}
+                  />
+                  <TextInput
+                    name="gpsMark"
+                    labelText="GPS mark"
+                    maxLength={10}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                </FormSection>
+              </section>
+              <section css={styles.section}>
+                <ListHeader title="Observation" />
+                <FormSection>
+                  <NumberInput
+                    name="numberOfAnimals"
+                    labelText="Number of animals"
+                    minValue={0}
+                    maxValue={99}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="numberOfCalves"
+                    labelText="Number of calves"
+                    minValue={0}
+                    maxValue={99}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="numberOfBoats"
+                    labelText="Number of boats"
+                    minValue={0}
+                    maxValue={999}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="directionOfTravel"
+                    labelText="Direction of travel"
+                    options={direction}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <TextAreaInput
+                    name="comments"
+                    labelText="Comments"
+                    maxLength={500}
+                    isDisabled={isViewOnly}
+                    isDouble
+                  />
+                  <TextAreaInput
+                    name="groupComposition"
+                    labelText="Group composition"
+                    maxLength={255}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="groupCohesion"
+                    labelText="Group cohesion"
+                    options={groupCohesion}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="behaviour"
+                    labelText="Behaviour"
+                    options={behaviour}
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="surfaceBout"
+                    labelText="Surface bout"
+                    minValue={0}
+                    maxValue={99}
+                    isShort
+                    decimalPrecision={5}
+                    isDisabled={isViewOnly}
+                  />
+                </FormSection>
+              </section>
+              <br />
+
+              <section css={styles.section}>
+                <ListHeader title="Environment" />
+                <FormSection>
+                  <NumberWithCheckbox
+                    numberInputName="waterDepth"
+                    labelText="Water depth (m)"
+                    minValue={0}
+                    maxValue={9999}
+                    isShort
+                    decimalPrecision={3}
+                    isDisabled={isViewOnly}
+                    checkboxName="waterDepthBeyondSoundings"
+                    checkboxLabel="Beyond soundings"
+                  />
+                  <NumberInput
+                    name="waterTemp"
+                    labelText="Water temp (°C)"
+                    minValue={15}
+                    maxValue={40}
+                    isShort
+                    decimalPrecision={5}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="bottomSubstrate"
+                    labelText="Bottom substrate"
+                    options={bottomSubstrate}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="cloudCover"
+                    labelText="Cloud cover"
+                    options={cloudCover}
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="beaufortSeaState"
+                    labelText="Beaufort sea state"
+                    options={beaufortSeaState}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="swellWaveHeight"
+                    labelText="Swell / Wave height (ft)"
+                    options={swellWaveHeight}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <Select
+                    name="tideState"
+                    labelText="Tide state"
+                    options={tideState}
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                </FormSection>
+              </section>
+              <br />
+              <section css={styles.section}>
+                <FormSection isOneLine>
+                  <NumberInput
+                    name="distance"
+                    labelText="Distance (m)"
+                    minValue={0}
+                    maxValue={9999}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="bearing"
+                    labelText="Bearing (°)"
+                    minValue={0}
+                    maxValue={360}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                  <NumberInput
+                    name="aspect"
+                    labelText="Aspect (°)"
+                    minValue={0}
+                    maxValue={360}
+                    isInteger
+                    isShort
+                    isDisabled={isViewOnly}
+                  />
+                </FormSection>
+              </section>
               <div css={utilities.form.legend}>
                 <span>*</span>required fields
               </div>

--- a/app/src/constants/formOptions/tideState.js
+++ b/app/src/constants/formOptions/tideState.js
@@ -1,1 +1,9 @@
-export default ["High", "Ebb", "Low", "Flood", "Slack", "High Slack", "Low Slack", "Not Noted"];
+export default [
+  "High",
+  "Ebb",
+  "Low",
+  "Flood",
+  "High Slack",
+  "Low Slack",
+  "Not Noted",
+];


### PR DESCRIPTION
Remove "slack" from the tide state options is a follow up of the pull-request from Linda Roy (dev-deployed-321). It turns out that after adding "High Slack" and "Low Slack" to the tide state options, just "Slack" is no longer necessary.

I've changed the layout and grouping to `HabitatUseForm` in the same way as `EncounterForm` was done, in accordance with the [wireframe](https://drive.google.com/drive/folders/1yEOVBOyl3Pz-O1VWDdBxfZxAVLiLl9k9?usp=sharing) in story #106. The only differences are that the `Time & position` section is at the top (as requested by Charlotte and confirmed by Linda) and that the text areas such as `groupComposition` aren't as tall as in the wireframe (Jen says it's fine).

I thought `background-color: none;` on sections in `EncounterForm` and `HabitatUseForm` are simple enough not to extract into a utility css in the utilities directory. I'm happy to make that change if the reviewer would like me to.